### PR TITLE
Added binary search, tests and updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ let xp = [0.1, 0.65, 0.9];
 assert_eq!(interp_array(&x, &y, &xp, &InterpMode::default()), [0.5, 3.25, 3.75]);
 ```
 
+> [!WARNING]  
+> `x` is expected to be strictly increasing, but this is not explicitly enforced. However, if the sequence `x` is not strictly increasing, interpolation results are meaningless.
+
 Full API documentation is available on [docs.rs][docs].
 
 [docs]: https://docs.rs/interp/latest/interp/


### PR DESCRIPTION
Closes #4 

Changes to use binary search for finding the index in `prev_index`. Also added a comemnt that `x` needs to be strictly increasing (which already the case before but not stated).